### PR TITLE
Update return buttons to point to novafleet.fr

### DIFF
--- a/simulateur-economie.html
+++ b/simulateur-economie.html
@@ -67,7 +67,7 @@ input:focus{outline:none;border-color:#aaa}
     <p style="margin-top:12px;color:#8c8f93;font-size:14px">* Champs obligatoires</p>
     <div style="margin-top:18px;display:flex;gap:10px;flex-wrap:wrap">
       <button class="btn btn-primary" type="submit">Calculer mes gains</button>
-      <a class="btn btn-secondary" href="https://gestion-sinistres-55dwwtu.gamma.site/">⬅️ Retour au site</a>
+      <a class="btn btn-secondary" href="https://www.novafleet.fr/">⬅️ Retour sur www.novafleet.fr</a>
     </div>
   </form>
 
@@ -83,7 +83,7 @@ input:focus{outline:none;border-color:#aaa}
       <div class="kpi">Jours évités / an<br><b id="kpiJours">—</b></div>
       <div class="kpi">Taux appliqués<br><b>+15 % sinistres • +25 % restitutions</b></div>
     </div>
-    <div style="margin-top:14px"><a class="btn btn-primary" href="https://gestion-sinistres-55dwwtu.gamma.site/">⬅️ Retour au site NovaFleet</a></div>
+    <div style="margin-top:14px"><a class="btn btn-primary" href="https://www.novafleet.fr/">⬅️ Retour sur www.novafleet.fr</a></div>
     <p class="note">Hypothèses : +15 % (base 2 000 € HT / sinistre), +25 % (base 1 000 € / restitution), 2 h gagnées / sinistre, 1,5 j d’immobilisation évité / sinistre.</p>
   </section>
 </div>

--- a/simulateur-rse.html
+++ b/simulateur-rse.html
@@ -65,7 +65,7 @@ input{width:100%;padding:11px 12px;border:1px solid #d2d5d9;border-radius:10px;f
         <div><label>Nb restitutions / ventes / an *</label><input type="number" id="restitutions" min="0" required placeholder="ex : 30"></div>
       </div>
       <button type="submit" class="btn">Calculer mon impact</button>
-      <a class="btn secondary" href="https://gestion-sinistres-55dwwtu.gamma.site/">⬅️ Retour au site</a>
+      <a class="btn secondary" href="https://www.novafleet.fr/">⬅️ Retour sur www.novafleet.fr</a>
     </form>
 
     <div id="resultat" class="result" style="display:none"></div>


### PR DESCRIPTION
## Summary
- update the “Retour” buttons in both simulators to point to https://www.novafleet.fr/
- adjust the button labels to read "Retour sur www.novafleet.fr" after form submission

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d156d48af483249885835fbbfd3cd1